### PR TITLE
Solve the problem that the vault query fails when the vault filter in…

### DIFF
--- a/src/main/java/net/corda/explorer/rpc/NodeRPCClient.java
+++ b/src/main/java/net/corda/explorer/rpc/NodeRPCClient.java
@@ -26,7 +26,6 @@ import java.util.Map;
 @Component
 public class NodeRPCClient {
     private static final Logger logger = LoggerFactory.getLogger(NodeRPCClient.class);
-
     private static CordaRPCOps rpcProxy;
     private static Session sshSession;
     private Map<String, String> partyKeyMap = new HashMap<>();

--- a/src/main/java/net/corda/explorer/service/impl/VaultServiceImpl.java
+++ b/src/main/java/net/corda/explorer/service/impl/VaultServiceImpl.java
@@ -28,6 +28,9 @@ public class VaultServiceImpl implements VaultService {
                 new PageSpecification(filter.getOffset() + 1, filter.getPageSize());
 
         /* ContractStateType Filters */
+        if(contractStateClassMap.size()==0){
+            getVaultFilters();
+        }
         Set<Class<ContractState>> stateType = ImmutableSet.of(ContractState.class);
         HashSet<Class<ContractState>> stateTypeSet = new HashSet<>();
         if(filter.getStateTypes() != null &&  filter.getStateTypes().size() > 0){


### PR DESCRIPTION
…terface is not called when the service is started for the first time

if not running the interface /vault-filter, the contractStateClassMap is null. And theContractStateType Filters will not work.
        So add the if condition, when the contractStateClassMap's size is 0, then use getVaultFilters() method to full the contractStateClassMap.